### PR TITLE
Setup cargo-rdme CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,18 @@ jobs:
       - uses: dtolnay/install@cargo-docs-rs
       - run: cargo docs-rs
 
+  cargo-rdme:
+    name: cargo-rdme --check
+    needs: pre_ci
+    if: needs.pre_ci.outputs.continue
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-rdme
+      - run: cargo rdme --check
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest


### PR DESCRIPTION
Verifies that `README.md` and crate docs are never out of sync by using [`cargo-rdme`](https://github.com/orium/cargo-rdme)