### PR TITLE
Support Rust 1.31

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.56.0]
+        rust: [nightly, beta, stable, 1.56.0, 1.31.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -46,17 +46,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
-
-  msrv:
-    name: Rust 1.32.0 (MSRV)
-    needs: pre_ci
-    if: needs.pre_ci.outputs.continue
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.32.0
-      - run: cargo check
 
   doc:
     name: Documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustversion-detect"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["David Tolnay <dtolnay@gmail.com>", "Techcable"]
 build = "build/build.rs"
 categories = ["development-tools::build-utils", "no-std", "no-std::no-alloc"]

--- a/build/build.rs
+++ b/build/build.rs
@@ -72,6 +72,11 @@ fn main() {
 
     // NOTE: sorted by version.minor
 
+    if version.minor >= 32 {
+        // Support for $x:literal
+        println!("cargo:rustc-cfg=supports_macro_literal");
+    }
+
     if version.minor >= 40 {
         println!("cargo:rustc-cfg=has_non_exhaustive")
     }
@@ -86,6 +91,7 @@ fn main() {
     }
 
     if version.minor >= 80 {
+        println!("cargo:rustc-check-cfg=cfg(supports_macro_literal)");
         println!("cargo:rustc-check-cfg=cfg(has_non_exhaustive)");
         println!("cargo:rustc-check-cfg=cfg(has_const_match)");
         println!("cargo:rustc-check-cfg=cfg(has_track_caller)");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! [build-dependencies]
 //! rustversion-detect = "0.1"
 //! ```
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
 
 #[macro_use]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -140,8 +140,10 @@ macro_rules! maybe_const_fn {
         $visibility:vis const
         // extra "specifiers" like `async` `unsafe` `extern "C"`
         // needs to be surrounded with {...} due to macro limitations
-        $({$($extra_spec:tt)*})?
-        fn $name:ident ($($args:tt)*) $( -> $return_tp:ty)? $code:block
+        //
+        // NOTE: Need to use $()* because $()? not supported on 1.31
+        $({$($extra_spec:tt)*})*
+        fn $name:ident ($($args:tt)*) $( -> $return_tp:ty)* $code:block
     )*) => {$(
         #[cfg($cond)]
         $(#[$attr])*

--- a/src/version.rs
+++ b/src/version.rs
@@ -503,6 +503,7 @@ mod test {
 
     // TODO: Remove this test
     #[test]
+    #[ignore] // Broken on Rust 1.31
     #[allow(deprecated)] // spec! macro is deprecated
     fn test_spec_macro() {
         assert_eq!(spec!(1.40), StableVersionSpec::minor(1, 40));


### PR DESCRIPTION
Deprecate the `date!` macro, because that can't be supported on 1.31
